### PR TITLE
add npm deployment github actions

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/usermanagement",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A TypeScript library for authentication and user management",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "license": "InnoBridge",


### PR DESCRIPTION
This pull request introduces changes to enable publishing the `@innobridge/usermanagement` package to npm. The most important changes include adding a GitHub Actions workflow for automated publishing and updating the package version in `package.json`.

### Workflow for npm publishing:

* [`.github/workflows/publish-to-npm.yaml`](diffhunk://#diff-ba8d164be0b8439ec65972dd4bb482cd3f161af8113995eb0ca17131c73fc745R1-R21): Added a new GitHub Actions workflow to automate publishing the package to npm whenever a release is published. This includes setting up Node.js, installing dependencies, and running `npm publish` with provenance and public access.

### Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.0` to `0.0.1` to prepare for the initial release.