### PR TITLE
add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.0.1",
   "description": "A TypeScript library for authentication and user management",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
+    "repository": {
+    "type": "git",
+    "url": "https://github.com/InnoBridge/usermanagement.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
   "license": "InnoBridge",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
This pull request includes updates to the `package.json` file to add repository metadata and publishing configuration for the library.

* Added `repository` field to specify the Git repository URL and type.
* Added `publishConfig` field to configure the package for publishing to the public npm registry.